### PR TITLE
Update contributing doc to add details about PR labels

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -33,7 +33,7 @@ We follow the [SymVer](https://semver.org/) versioning strategy: \[MAJOR\].\[MIN
 * For non-breaking feature changes, \[MINOR\] should be incremented.  This can be accomplished by running `./version.sh -u -n`
 * For major and/or breaking changes, \[MAJOR\] should be incremented.  This can be accomplished by running `./version.sh -u -m`
 
-To ensure that all product versioning is consistent, our CI builds will execute `./version.sh -c` to check all known instances of version in our YAML, TOML, and code. This will also check to make sure that version.txt has been changed. If a pull request is needed where the version should not be changed, include `[SAME VERSION]` in the pull request title.
+To ensure that all product versioning is consistent, our CI builds will execute `./version.sh -c` to check all known instances of version in our YAML, TOML, and code. This will also check to make sure that version.txt has been changed. If a pull request is needed where the version should not be changed, add `same version` label to the pull request.
 
 > Note for MacOS users: `version.sh` uses the GNU `sed` command under-the-hood, but MacOS has built-in its own version. We recommend installing the GNU version via `brew install gnu-sed`. Then follow the brew instructions on how to use the installed GNU `sed` instead of the MacOS one.
 
@@ -49,15 +49,16 @@ Akri follows similar logging conventions as defined by the [Tracing crate](https
 | debug | Verbose information for high-level debugging and diagnoses of issues |
 | trace | Extremely verbose information for developers of Akri |
 
-## PR title flags
+## PR labels
+Akri's workflows check for two labels in the PRs in order to decide whether to execute certain checks. 
 
-Akri's workflows check for three flags in the titles of PRs in order to decide whether to execute certain checks.
+The [version check workflow](https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml) will run, ensuring you have increased the version number, unless you (A) only change a file that is on an ignored path of the workflow, such as all `*.md` files OR (B) add the `same version` label to the pull request. Use this label if your change will trigger the workflow and the version should not be changed by your PR. The label will cause the check to automatically succeed.
 
-The [version check workflow](https://github.com/project-akri/akri/blob/main/.github/workflows/check-versioning.yml) will run, ensuring you have increased the version number, unless you (A) only change a a file that is on an ignored path of the workflow, such as all `*.md` files OR (B) specify the `[SAME VERSION]` flag. Use this flag if your change will trigger the workflow and the version should not be changed by your PR. The flag will cause the check to automatically succeed.
+Akri has some intermediate containers that decrease the build time of the more frequently built final containers. These intermediate builds are long running and should only be run when absolutely needed. If your PR triggers a workflow to build them, you will see the workflow fail and get a message that requests that you add `build dependency containers` label to your PR to start the build. 
 
-Akri has some intermediate containers that decrease the build time of the more frequently built final containers. These intermediate builds are long running and should only be run when absolutely needed. If your PR triggers a workflow to build them, you will see the workflow fail and get a message that requests that you add a tag to your PR to either allow them to build (`[ALLOW INTERMEDIATE BUILDS]`) or (`[IGNORE INTERMEDIATE BUILDS`).
-
-Please add any appropriate flags to the end of your PR title.
+You can add labels by commenting:
+  - /add-build-dependency-containers-label
+  - /add-same-version-label
 
 ## CLA
 

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -33,7 +33,7 @@ We follow the [SymVer](https://semver.org/) versioning strategy: \[MAJOR\].\[MIN
 * For non-breaking feature changes, \[MINOR\] should be incremented.  This can be accomplished by running `./version.sh -u -n`
 * For major and/or breaking changes, \[MAJOR\] should be incremented.  This can be accomplished by running `./version.sh -u -m`
 
-To ensure that all product versioning is consistent, our CI builds will execute `./version.sh -c` to check all known instances of version in our YAML, TOML, and code. This will also check to make sure that version.txt has been changed. If a pull request is needed where the version should not be changed, add `same version` label to the pull request.
+To ensure that all product versioning is consistent, our CI builds will execute `./version.sh -c` to check all known instances of version in our YAML, TOML, and code. This will also check to make sure that version.txt has been changed. If a pull request is needed where the version should not be changed, add `same version` label to the pull request by commenting `/add-same-version-label`.
 
 > Note for MacOS users: `version.sh` uses the GNU `sed` command under-the-hood, but MacOS has built-in its own version. We recommend installing the GNU version via `brew install gnu-sed`. Then follow the brew instructions on how to use the installed GNU `sed` instead of the MacOS one.
 
@@ -57,8 +57,8 @@ The [version check workflow](https://github.com/project-akri/akri/blob/main/.git
 Akri has some intermediate containers that decrease the build time of the more frequently built final containers. These intermediate builds are long running and should only be run when absolutely needed. If your PR triggers a workflow to build them, you will see the workflow fail and get a message that requests that you add `build dependency containers` label to your PR to start the build. 
 
 You can add labels by commenting:
-  - /add-build-dependency-containers-label
-  - /add-same-version-label
+  - `/add-build-dependency-containers-label`
+  - `/add-same-version-label`
 
 ## CLA
 


### PR DESCRIPTION
This change is associated with the PR in Akri main: https://github.com/project-akri/akri/pull/426.
Instead of running workflows based on the flags in PR titles, we made changes so that workflow runs are now triggered by PR labels. This change is to update the contributing docs and add details about the PR labels.