### PR TITLE
Update docs with latest rust version and to point to prod Helm Chart

### DIFF
--- a/docs/development/broker-development.md
+++ b/docs/development/broker-development.md
@@ -41,7 +41,7 @@ Once you have created a broker, you can ask Akri to automatically deploy it to a
 
 ```bash
 helm repo add akri-helm-charts https://project-akri.github.io/akri/
-helm install akri akri-helm-charts/akri-dev \
+helm install akri akri-helm-charts/akri \
     $AKRI_HELM_CRICTL_CONFIGURATION \
     --set udev.discovery.enabled=true \
     --set udev.configuration.enabled=true \
@@ -70,7 +70,7 @@ You can request that additional environment variables are set in Pods that reque
 
 ```bash
   helm repo add akri-helm-charts https://project-akri.github.io/akri/
-  helm install akri akri-helm-charts/akri-dev \
+  helm install akri akri-helm-charts/akri \
   $AKRI_HELM_CRICTL_CONFIGURATION \
   --set udev.discovery.enabled=true \
   --set udev.configuration.enabled=true \

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -24,10 +24,10 @@ The majority of Akri is written in Rust. To install Rust and Akri's component's 
 ```sh
 ./build/setup.sh
 ```
-If you previously installed Rust ensure you are using the v1.55.0 toolchain that Akri's build system uses:
+If you previously installed Rust ensure you are using the v1.58.1 toolchain that Akri's build system uses:
 ```sh
-sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.55.0
-rustup default 1.55.0
+sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.58.1
+rustup default 1.58.1
 cargo version
 ``` 
 
@@ -39,14 +39,14 @@ cargo version
     ./build/setup.sh
     ```
 
-    If you previously installed Rust, ensure you are using the v1.55.0 toolchain that Akri's build system uses:
+    If you previously installed Rust, ensure you are using the v1.58.1 toolchain that Akri's build system uses:
     ```sh
-    sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.55.0
+    sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.58.1
     ``` 
-    Then, configure your current shell to see Cargo and set `v1.55.0` as default toolchain.
+    Then, configure your current shell to see Cargo and set `v1.58.1` as default toolchain.
     ```sh
     source $HOME/.cargo/env
-    rustup default 1.55.0
+    rustup default 1.58.1
     cargo version
     ```
 

--- a/docs/user-guide/customizing-an-akri-installation.md
+++ b/docs/user-guide/customizing-an-akri-installation.md
@@ -194,8 +194,8 @@ Want to change what broker is deployed to already discovered devices or deploy a
 
 This can be illustrated using Akri's [mock debug echo Discovery Handler](../development/debugging.md). The following installation deploys a BusyBox Job
 to each discovered mock device. That Job simply echos "Hello World".
-```
-helm install akri akri-helm-charts/akri-dev \
+```sh
+helm install akri akri-helm-charts/akri \
   --set agent.allowDebugEcho=true \
   --set debugEcho.discovery.enabled=true \
   --set debugEcho.configuration.brokerJob.image.repository=busybox \
@@ -204,10 +204,11 @@ helm install akri akri-helm-charts/akri-dev \
   --set debugEcho.configuration.brokerJob.command[2]="echo 'Hello World'"
   --set debugEcho.configuration.enabled=true
 ```
+
 Say you are feeling more exuberant and want the Job to echo "Hello Amazing World", you can update the `brokerSpec` like so:
 
-```
-helm upgrade akri akri-helm-charts/akri-dev \
+```sh
+helm upgrade akri akri-helm-charts/akri \
   --set agent.allowDebugEcho=true \
   --set debugEcho.discovery.enabled=true \
   --set debugEcho.configuration.brokerJob.image.repository=busybox \
@@ -217,7 +218,7 @@ helm upgrade akri akri-helm-charts/akri-dev \
   --set debugEcho.configuration.enabled=true
 ```
 
-New Jobs will be spun up. 
+New Jobs will be spun up.
 
 > Note: The Agent and Controller can only gracefully handle changes to the `brokerSpec`. If any other parts of the Configuration are modified, the Agent will restart discovery, deleting and recreating the Instances.
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -123,10 +123,8 @@ helm install akri akri-helm-charts/akri \
 
 A terminating BusyBox Job broker could have been specified instead by setting the image of the `brokerJob` instead of the `brokerPod`.
 
-> Note: Jobs are not released yet, so use the `akri-dev` chart to try them out.
-
 ```bash
-helm install akri akri-helm-charts/akri-dev \
+helm install akri akri-helm-charts/akri \
     $AKRI_HELM_CRICTL_CONFIGURATION
     --set udev.discovery.enabled=true \
     --set udev.configuration.enabled=true \


### PR DESCRIPTION
In preparation of Akri's next release, this points to the new Rust version and the production Helm charts.