### PR TITLE
Ensure only USB cameras with capture capabilities are discovered in udev examples

### DIFF
--- a/docs/demos/usb-camera-demo-rpi4.md
+++ b/docs/demos/usb-camera-demo-rpi4.md
@@ -100,7 +100,7 @@ You tell Akri what you want to find with an Akri Configuration, which is one of 
 2. any additional device filtering
 3. an image for a Pod (that we call a "broker") that you want to be automatically deployed to utilize each discovered device
 
-For this demo, we will specify (1) Akri's udev Discovery Handler, which is used to discover devices in the Linux device file system. Akri's udev Discovery Handler supports (2) filtering by udev rules. We want to find all video devices in the Linux device file system, which can be specified with the udev rule `KERNEL=="video[0-9]*"`. Say we wanted to be more specific and only discover devices made by Great Vendor, we could adjust our rule to be `KERNEL=="video[0-9]*"\, ENV{ID_VENDOR}=="Great Vendor"`. For (3) a broker Pod image, we will use a sample container that Akri has provided that pulls frames from the cameras and serves them over gRPC. 
+For this demo, we will specify (1) Akri's udev Discovery Handler, which is used to discover devices in the Linux device file system. Akri's udev Discovery Handler supports (2) filtering by udev rules. We want to find all video capture devices in the Linux device file system, which can be specified with the udev rule `KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"`. Say we wanted to be more specific and only discover devices made by Great Vendor, we could adjust our rule to be `KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"\, ENV{ID_VENDOR}=="Great Vendor"`. For (3) a broker Pod image, we will use a sample container that Akri has provided that pulls frames from the cameras and serves them over gRPC. 
 
 All of Akri's components can be deployed by specifying values in its Helm chart during an installation. Instead of having to build a Configuration from scratch, Akri has provided [Helm templates](https://github.com/project-akri/akri/blob/main/deployment/helm/templates) for Configurations for each supported Discovery Handler. Lets customize the generic [udev Configuration Helm template](https://github.com/project-akri/akri/blob/main/deployment/helm/templates/udev-configuration.yaml) with our three specifications above. We can also set the name for the Configuration to be `akri-udev-video`.
 
@@ -117,7 +117,7 @@ In order for the Agent to know how to discover video devices, the udev Discovery
         --set udev.discovery.enabled=true \
         --set udev.configuration.enabled=true \
         --set udev.configuration.name=akri-udev-video \
-        --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"' \
+        --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"' \
         --set udev.configuration.brokerPod.image.repository="ghcr.io/project-akri/akri/udev-video-broker" 
     ```
 
@@ -204,19 +204,8 @@ Look at the Configuration and Instances in more detail.
       --set udev.discovery.enabled=true \
       --set udev.configuration.enabled=true \
       --set udev.configuration.name=akri-udev-video \
-      --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_VENDOR}=="Microsoft"' \
+      --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"\, ENV{ID_VENDOR}=="Microsoft"' \
       --set udev.configuration.brokerPod.image.repository="ghcr.io/project-akri/akri/udev-video-broker" 
    ```
 
-   As another example, to make sure that the camera has a capture capability rather than just being a video output device, modify the udev rule as follows: 
-   ```bash
-   helm repo add akri-helm-charts https://project-akri.github.io/akri/
-   helm install akri akri-helm-charts/akri \
-      $AKRI_HELM_CRICTL_CONFIGURATION \
-      --set udev.discovery.enabled=true \
-      --set udev.configuration.enabled=true \
-      --set udev.configuration.name=akri-udev-video \
-      --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}=="*:capture:*"' \
-      --set udev.configuration.brokerPod.image.repository="ghcr.io/project-akri/akri/udev-video-broker" 
-   ```
 5. Discover other udev devices by creating a new udev configuration and broker. Learn more about the udev Discovery Handler Configuration [here](../discovery-handlers/udev.md).

--- a/docs/demos/usb-camera-demo.md
+++ b/docs/demos/usb-camera-demo.md
@@ -101,7 +101,7 @@ You tell Akri what you want to find with an Akri Configuration, which is one of 
 2. any additional device filtering 
 3. an image for a Pod (that we call a "broker") that you want to be automatically deployed to utilize each discovered device
 
-For this demo, we will specify (1) Akri's udev Discovery Handler, which is used to discover devices in the Linux device file system. Akri's udev Discovery Handler supports (2) filtering by udev rules. We want to find all video devices in the Linux device file system, which can be specified with the udev rule `KERNEL=="video[0-9]*"`. Say we wanted to be more specific and only discover devices made by Great Vendor, we could adjust our rule to be `KERNEL=="video[0-9]*"\, ENV{ID_VENDOR}=="Great Vendor"`. For (3) a broker Pod image, we will use a sample container that Akri has provided that pulls frames from the cameras and serves them over gRPC.
+For this demo, we will specify (1) Akri's udev Discovery Handler, which is used to discover devices in the Linux device file system. Akri's udev Discovery Handler supports (2) filtering by udev rules. We want to find all video capture devices in the Linux device file system, which can be specified with the udev rule `KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"`. Say we wanted to be more specific and only discover devices made by Great Vendor, we could adjust our rule to be `KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"\, ENV{ID_VENDOR}=="Great Vendor"`. For (3) a broker Pod image, we will use a sample container that Akri has provided that pulls frames from the cameras and serves them over gRPC.
 
 All of Akri's components can be deployed by specifying values in its Helm chart during an installation. Instead of having to build a Configuration from scratch, Akri has provided [Helm templates](https://github.com/project-akri/akri/blob/main/deployment/helm/templates) for Configurations for each supported Discovery Handler. Lets customize the generic [udev Configuration Helm template](https://github.com/project-akri/akri/blob/main/deployment/helm/templates/udev-configuration.yaml) with our three specifications above. We can also set the name for the Configuration to be `akri-udev-video`. Also, if using MicroK8s or K3s, configure the crictl path and socket using the `AKRI_HELM_CRICTL_CONFIGURATION` variable created when setting up your cluster.
 
@@ -118,7 +118,7 @@ In order for the Agent to know how to discover video devices, the udev Discovery
         --set udev.discovery.enabled=true \
         --set udev.configuration.enabled=true \
         --set udev.configuration.name=akri-udev-video \
-        --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"' \
+        --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"' \
         --set udev.configuration.brokerPod.image.repository="ghcr.io/project-akri/akri/udev-video-broker"
    ```
 
@@ -270,19 +270,7 @@ After installing Akri, since the /dev/video1 and /dev/video2 devices are running
       --set udev.discovery.enabled=true \
       --set udev.configuration.enabled=true \
       --set udev.configuration.name=akri-udev-video \
-      --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_VENDOR}=="Microsoft"' \
-      --set udev.configuration.brokerPod.image.repository="ghcr.io/project-akri/akri/udev-video-broker" 
-   ```
-
-   As another example, to make sure that the camera has a capture capability rather than just being a video output device, modify the udev rule as follows: 
-   ```bash
-   helm repo add akri-helm-charts https://project-akri.github.io/akri/
-   helm install akri akri-helm-charts/akri \
-      $AKRI_HELM_CRICTL_CONFIGURATION \
-      --set udev.discovery.enabled=true \
-      --set udev.configuration.enabled=true \
-      --set udev.configuration.name=akri-udev-video \
-      --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}=="*:capture:*"' \
+      --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"\, ENV{ID_VENDOR}=="Microsoft"' \
       --set udev.configuration.brokerPod.image.repository="ghcr.io/project-akri/akri/udev-video-broker" 
    ```
 5. Discover other udev devices by creating a new udev configuration and broker. Learn more about the udev Discovery Handler Configuration [here](../discovery-handlers/udev.md).

--- a/docs/development/broker-development.md
+++ b/docs/development/broker-development.md
@@ -46,7 +46,7 @@ helm install akri akri-helm-charts/akri \
     --set udev.discovery.enabled=true \
     --set udev.configuration.enabled=true \
     --set udev.configuration.name=akri-udev-video \
-    --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"' \
+    --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"' \
     --set udev.configuration.brokerPod.image.repository="ghcr.io/brokers/camera-broker" \
     --set udev.configuration.brokerPod.image.tag="v0.0.1"
 ```
@@ -75,7 +75,7 @@ You can request that additional environment variables are set in Pods that reque
   --set udev.discovery.enabled=true \
   --set udev.configuration.enabled=true \
   --set udev.configuration.name=akri-udev-video \
-  --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"' \
+  --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"' \
   --set udev.configuration.brokerPod.image.repository="ghcr.io/project-akri/akri/udev-video-broker" \
   --set udev.configuration.brokerProperties.FORMAT='JPEG' \
   --set udev.configuration.brokerProperties.RESOLUTION_WIDTH='1000' \

--- a/docs/user-guide/customizing-an-akri-installation.md
+++ b/docs/user-guide/customizing-an-akri-installation.md
@@ -106,7 +106,7 @@ helm install akri akri-helm-charts/akri \
     $AKRI_HELM_CRICTL_CONFIGURATION \
     --set onvif.configuration.enabled=true \
     --set udev.configuration.enabled=true \
-    --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"'
+    --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"'
 ```
 
 {% hint style="info" %}
@@ -127,7 +127,7 @@ helm install udev-config akri-helm-charts/akri \
  --set agent.enabled=false \
  --set rbac.enabled=false \
  --set udev.configuration.enabled=true  \
- --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"'
+ --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"'
 
 helm install onvif-config akri-helm-charts/akri \
  --set controller.enabled=false \
@@ -174,7 +174,7 @@ helm upgrade akri akri-helm-charts/akri \
     $AKRI_HELM_CRICTL_CONFIGURATION \
     --set onvif.enabled=true \
     --set udev.enabled=true \
-    --set udev.udevRules[0]='KERNEL=="video[0-9]*"'
+    --set udev.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"'
 ```
 
 ### Adding additional Configurations via new Helm installations
@@ -187,7 +187,7 @@ helm install udev-config akri-helm-charts/akri \
  --set agent.enabled=false \
  --set rbac.enabled=false \
  --set udev.configuration.enabled=true  \
- --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"'
+ --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"'
 ```
 ## Modifying a broker
 Want to change what broker is deployed to already discovered devices or deploy a new Job to the devices? Instead of deleting and reapplying the Configuration, you can modify the `brokerSpec` of the Configuration using one of the strategies from the [section on modifying a deployed Configuration](#Modifying-a-deployed-Configuration).

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -115,7 +115,7 @@ helm install akri akri-helm-charts/akri \
     $AKRI_HELM_CRICTL_CONFIGURATION
     --set udev.discovery.enabled=true \
     --set udev.configuration.enabled=true \
-    --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"' \
+    --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"' \
     --set udev.configuration.brokerPod.image.repository=nginx
 ```
 
@@ -128,7 +128,7 @@ helm install akri akri-helm-charts/akri \
     $AKRI_HELM_CRICTL_CONFIGURATION
     --set udev.discovery.enabled=true \
     --set udev.configuration.enabled=true \
-    --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"' \
+    --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"' \
     --set udev.configuration.brokerJob.image.repository=busybox
 ```
 

--- a/docs/user-guide/monitoring-with-prometheus.md
+++ b/docs/user-guide/monitoring-with-prometheus.md
@@ -101,7 +101,7 @@ As an example, an `akri_frame_count` metric has been created in the sample [udev
         $AKRI_HELM_CRICTL_CONFIGURATION \
         --set udev.enabled=true \
         --set udev.name=akri-udev-video \
-        --set udev.udevRules[0]='KERNEL=="video[0-9]*"' \
+        --set udev.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}==":capture:"' \
         --set udev.brokerPod.image.repository="ghcr.io/project-akri/akri/udev-video-broker"
    ```
 


### PR DESCRIPTION
Some usb cameras use multiple kernel nodes, one for capture and others for metadata. This fixes the issue of discovering these extra metadata nodes as unique cameras (project-akri/akri#438) by modifying the udev rule to only discover cameras with capture capabilities. 