### PR TITLE
Add CODEOWNERS file for Akri Docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file is described here:  https://help.github.com/en/articles/about-code-owners
+
+# Global Owners: These members are Core Maintainers of Akri's Docs
+* @kate-goldenring @bfjelds @romoh @jiria @edrickwong


### PR DESCRIPTION
This ensures that maintainers are tagged as reviewers in PR by default