### PR TITLE
Update Rust version

### DIFF
--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -24,10 +24,10 @@ The majority of Akri is written in Rust. To install Rust and Akri's component's 
 ```sh
 ./build/setup.sh
 ```
-If you previously installed Rust ensure you are using the v1.58.1 toolchain that Akri's build system uses:
+If you previously installed Rust ensure you are using the v1.61.0 toolchain that Akri's build system uses:
 ```sh
-sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.58.1
-rustup default 1.58.1
+sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.61.0
+rustup default 1.61.0
 cargo version
 ``` 
 
@@ -39,14 +39,14 @@ cargo version
     ./build/setup.sh
     ```
 
-    If you previously installed Rust, ensure you are using the v1.58.1 toolchain that Akri's build system uses:
+    If you previously installed Rust, ensure you are using the v1.61.0 toolchain that Akri's build system uses:
     ```sh
-    sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.58.1
+    sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.61.0
     ``` 
-    Then, configure your current shell to see Cargo and set `v1.58.1` as default toolchain.
+    Then, configure your current shell to see Cargo and set `v1.61.0` as default toolchain.
     ```sh
     source $HOME/.cargo/env
-    rustup default 1.58.1
+    rustup default 1.61.0
     cargo version
     ```
 


### PR DESCRIPTION
Akri uses Rust 1.61.0. Update docs to appropriately reflect this.

Signed-off-by: Kate Goldenring <kagold@microsoft.com>