### PR TITLE
Add uniqueDevices spec to Configuration level resource proposal

### DIFF
--- a/proposals/configuration-level-resources.md
+++ b/proposals/configuration-level-resources.md
@@ -125,7 +125,7 @@ deviceUsage:
   akri.sh/akri-onvif-a19705-1: ""
 ```
 
-Assume Kubernetes shcedule a pod that request `2` CL devices to to `node-a`.
+Assume Kubernetes shcedule a pod that request `2` CL devices to `node-a`.
  After the pod scheduled to the node, 2 slots are reserved from the CL device plugin.  The CL resource capacity is `0 (2 - 2)` and 
  the IL resource capacity is `1`, respectively.  The capacity and deviceUsage become:
 
@@ -166,6 +166,47 @@ deviceUsage:
   akri.sh/akri-onvif-a19705-1: "node-a"
 ```
 
+On the other hand, if the resources are claimed by the IL device plugins, with the same example (2 nodes, 2 cameras, 2 capacity)
+ the deviceUsage will be updated as following:
+ 
+ Initiali state
+```yaml
+Capacity:
+  akri.sh/akri-onvif:         2
+  akri.sh/akri-onvif-8120fe:  2
+  akri.sh/akri-onvif-a19705:  2
+```
+
+```yaml
+deviceUsage:
+  akri.sh/akri-onvif-8120fe-0: ""
+  akri.sh/akri-onvif-8120fe-1: ""
+
+deviceUsage:
+  akri.sh/akri-onvif-a19705-0: ""
+  akri.sh/akri-onvif-a19705-1: ""
+```
+
+ Assume Kubernetes shcedule one pod for each discovered instance. `2` IL devices allocated to `node-a`.
+ After the pod scheduled to the node, 2 slots are reserved for the IL device plugins.  The IL resource capacity is `1 (2 - 1)` and 
+ the CL resource capacity is `0 (2 - 1 - 1)`, respectively.
+
+```yaml
+Capacity:
+  akri.sh/akri-onvif:         0
+  akri.sh/akri-onvif-8120fe:  1
+  akri.sh/akri-onvif-a19705:  1
+```
+
+```yaml
+deviceUsage:
+  akri.sh/akri-onvif-8120fe-0: "node-a"
+  akri.sh/akri-onvif-8120fe-1: ""
+
+deviceUsage:
+  akri.sh/akri-onvif-a19705-0: "node-a"
+  akri.sh/akri-onvif-a19705-1: ""
+```
 
 ## Deployment Strategies with Configuration-level resources
 

--- a/proposals/configuration-level-resources.md
+++ b/proposals/configuration-level-resources.md
@@ -210,21 +210,3 @@ is another advantage of using the Akri Controller rather than applying Deploymen
 this work on supporting Configuration level resources, the Akri's Controller could support a new deployment strategy for
 using these CL resources. The Controller also takes care of bringing down Pods when resources are no longer available,
 while Pods from manually created Deployments would continue to run even if the resources are no longer there.
-
-## Implementation of Configuration Device Plugin
-
-+------------+
-
-I            I
-
-+------------+
-	- CL resource and IL resource share the capacity pool. i.e. (# of allocated CL virtual devices + # of allocated IL virtual devices) <= capacity.
-	- The name of CL device plugin is the Akri Configuration name and follows the same convention of IL device plugin, i.e., replace ['.', '/'] with "-".
-	- The CL device plugin uses the same name schema as IL device plugin for virtual devices. The virtual device id reported by CL device plugin looks like <instance name>_<slot>.
-	- ConfigurationDevicePluginService represent the CL device plugin.  The ConfigurationDevicePluginService has similar struct as DevicePluginService.
-		○ DevicePluginService contains a list_and_watch_message_sender to notify refreshing list_and_watch, used by the DevicePluginService internally, a copy of list_and_watch_message_sender is stored in the associated InstanceInfo, used by external entity to refresh the DPS's list_and_watch.
-		○ ConfigurationDevicePluginService contains a list_and_watch_message_sender to notify refreshing list_and_watch, used by the ConfigurationDevicePluginService internally, a copy of list_and_watch_message_sender is store in the InstanceConfig, used by external entity to refresh the Configuration DPS's list_and_watch
-	- When IL DPS allocate a virtual device, it notify CL DPS to refresh list_and_watch ,and vice versa, CL DPS notify IL DPS to refresh list_and_watch when it allocates a virtual device.
-	- I added a new generic struct DevicePluginServiceTemplate<T: DevicePluginServiceInner> to eliminate the duplicate code.  DevicePluginServiceTemplate is a wrapper to wrap the worker DevicePluginServiceInner.  Both DevicePluginService and ConfigurationDevicePluginService implement the trait DevicePluginServiceInner.
-		
-	


### PR DESCRIPTION
This PR adds the new attribute called 'uniqueDevices' into Akri Configuration and adds the different behaviors of Configuration level resource based on the value of 'uniqueDevices'.
When uniqueDevices is true, CL device plugin allocates devices based on instance availablity.
When uniqueDevices is false, CL device plugin allocates devices based on deviceUsage availablity.