### PR TITLE
Added missing dependency and updated cargo version

### DIFF
--- a/docs/development/development-walkthrough.md
+++ b/docs/development/development-walkthrough.md
@@ -183,6 +183,7 @@ import (
   "net/http"
   "time"
   "strings"
+  "html"
 )
 
 const (

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -24,10 +24,10 @@ The majority of Akri is written in Rust. To install Rust and Akri's component's 
 ```sh
 ./build/setup.sh
 ```
-If you previously installed Rust ensure you are using the v1.68.1 toolchain that Akri's build system uses:
+If you previously installed Rust ensure you are using the v1.70 toolchain that Akri's build system uses:
 ```sh
-sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.68.1
-rustup default 1.68.1
+sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.70
+rustup default 1.70
 cargo version
 ``` 
 
@@ -39,14 +39,14 @@ cargo version
     ./build/setup.sh
     ```
 
-    If you previously installed Rust, ensure you are using the v1.68.1 toolchain that Akri's build system uses:
+    If you previously installed Rust, ensure you are using the v1.70 toolchain that Akri's build system uses:
     ```sh
-    sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.68.1
+    sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.70
     ``` 
-    Then, configure your current shell to see Cargo and set `v1.68.1` as default toolchain.
+    Then, configure your current shell to see Cargo and set `v1.70` as default toolchain.
     ```sh
     source $HOME/.cargo/env
-    rustup default 1.68.1
+    rustup default 1.70
     cargo version
     ```
 

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -24,10 +24,10 @@ The majority of Akri is written in Rust. To install Rust and Akri's component's 
 ```sh
 ./build/setup.sh
 ```
-If you previously installed Rust ensure you are using the v1.70 toolchain that Akri's build system uses:
+If you previously installed Rust ensure you are using the v1.73.0 toolchain that Akri's build system uses:
 ```sh
-sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.70
-rustup default 1.70
+sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.73.0
+rustup default 1.73.0
 cargo version
 ``` 
 
@@ -39,14 +39,14 @@ cargo version
     ./build/setup.sh
     ```
 
-    If you previously installed Rust, ensure you are using the v1.70 toolchain that Akri's build system uses:
+    If you previously installed Rust, ensure you are using the v1.73.0 toolchain that Akri's build system uses:
     ```sh
-    sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.70
+    sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.73.0
     ``` 
-    Then, configure your current shell to see Cargo and set `v1.70` as default toolchain.
+    Then, configure your current shell to see Cargo and set `v1.73.0` as default toolchain.
     ```sh
     source $HOME/.cargo/env
-    rustup default 1.70
+    rustup default 1.73.0
     cargo version
     ```
 


### PR DESCRIPTION
- updated cargo version in the toolchain install instruction to version 1.70 as it is required by cargo-generate which is used to create a discovery-handler project from a template
- added "html" package import to the Go module for the http server because it is required as dependency in the build step (docker build)
