### PR TITLE
Adapt documentation to take new build system into account

### DIFF
--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -16,7 +16,7 @@ In essence, Akri components can be thought of as:
 
 The Akri core components are the containers that provide Akri's functionality. They include the agent, the controller, the webhook and the discovery handlers. All of these are written in Rust.
 
-The samples containers are a set of brokers and applications written either in .NET, python or Rust that are used in this documentation examples.
+The samples containers are a set of brokers and applications that can be written in any language, such as .NET, python or Rust. They are used in documentation examples, quickstarts, and demos.
 
 All components are built with a `make` command. These are the supporting Makefiles:
 

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -1,167 +1,117 @@
 # Building Akri Containers
 
-Building Akri containers, whether locally or in the automated CI builds, leverages the same set of `make` commands.
+Building Akri containers, whether locally or in the automated CI builds, leverages the same set of Dockerfiles. In order to help with local development, a set of `Makefile` exists.
 
-In essence, Akri components can be thought of as: 
+The Makefiles are using `docker buildx` behind the scenes, ensure you have it installed, if you want to build for foreign architectures, you must also ensure you have correctly set up your docker builder to do so (see [Docker buildx documentation](https://github.com/docker/buildx#building-multi-platform-images))
 
-1. Runtime components 
+In essence, Akri components can be thought of as:
+
+1. Runtime components
     1. Rust code: containers based on Rust code are built using `Cargo cross` and subsequent `docker build` commands include the cross-built binaries.
-        > Note: For Rust code, `build/Dockerfile.*` does NOT run `cargo build`, instead they simply copy cross-built binaries into the container 
-    2. Other code: these containers can be .NET or python or whatever else ... the `build/Dockerfile.*` must do whatever building is required. 
+        > Note: For Rust code, `build/Dockerfile.*` does NOT run `cargo build`, instead they simply copy cross-built binaries into the container
+    2. Other code: these containers can be .NET or python or whatever else ... the `build/Dockerfile.*` must do whatever building is required.
 2. Intermediate components: these containers are used as part of the build process and are not used in production explicitly
 
-## Runtime components
+## Akri components
 
-The Akri runtime components are the containers that provide Akri's functionality. They include the agent, the controller, the webhook, the brokers, and the applications. The majority of Akri runtime components are written in Rust, but there are several components that are written in .NET or python.
+The Akri core components are the containers that provide Akri's functionality. They include the agent, the controller, the webhook and the discovery handlers. All of these are written in Rust.
 
-All of the runtime components are built with a `make` command. These are the supporting makefiles:
+The samples containers are a set of brokers and applications written either in .NET, python or Rust that are used in this documentation examples.
+
+All components are built with a `make` command. These are the supporting Makefiles:
 
 * `Makefile`: this provides a single point of entry to build any Akri component
-* `build/akri-containers.mk`: this provides the build and push functionality for Akri containers
-* `build/akri-rust-containers.mk`: this provides a simple definition to build and push Akri components written in Rust
-* `build/akri-dotnet-containers.mk`: this provides a simple definition to build and push Akri components written in .NET
-* `build/akri-python-containers.mk`: this provides a simple definition to build and push Akri components written in Python
+* `build/akri-containers.mk`: this provides the build and push functionality for Akri core containers
+* `build/samples.mk`: this provides the build and push functionality for containers used in the samples and documentation
+* `build/intermediate-container.mk`: this provides the build and push functionality for the opcvsharp base container
 
 ### Configurability
 
 The makefiles allow for several configurations:
 
-* BUILD\_AMD64: if set not to 1, the make commands will ignore AMD64
-* BUILD\_ARM32: if set not to 1, the make commands will ignore ARM32
-* BUILD\_ARM64: if set not to 1, the make commands will ignore ARM64
+* PUSH: if set, the make commands will push the built container images to the registry
+* LOAD: if set, the make command will load the built container images into the local docker daemon
+* PLATFORMS: space separated list of architectures to build for (default to local architecture in LOAD mode, and to `"amd64 arm64 arm/v7"` otherwise)
 * REGISTRY: allows configuration of the container registry (defaults to imaginary: devcaptest.azurecr.io)
 * UNIQUE\_ID: allows configuration of container registry account (defaults to $USER)
 * PREFIX: allows configuration of container registry path for containers
 * LABEL\_PREFIX: allows configuration of container labels
-* CACHE\_OPTION: when `CACHE_OPTION=--no-cache`, the `docker build` commands will not use local caches
 
 ### Local development usage
 
 For a local build, some typical patterns are:
 
-* `make akri-build`: run Rust cross-build for all platforms
-* `BUILD_AMD64=0 BUILD_ARM32=0 BUILD_ARM64=1 make akri-build`: run Rust cross-build for ARM64
-* `PREFIX=ghcr.io/myaccount make akri`: builds all of the Akri containers and stores them in a container registry, `ghcr.io/myaccount`.
-* `PREFIX=ghcr.io/myaccount make akri`: builds all of the Akri containers and stores them in a container registry, `ghcr.io/myaccount`.
-* `PREFIX=ghcr.io/myaccount LABEL_PREFIX=local make akri`: builds all of the Akri containers and stores them in a container registry, `ghcr.io/myaccount` with labels prefixed with `local`.
-* `PREFIX=ghcr.io/myaccount BUILD_AMD64=1 BUILD_ARM32=0 BUILD_ARM64=0 make akri`: builds all of the Akri containers for AMD64 and stores them in a container registry, `ghcr.io/myaccount`.
-* `PREFIX=ghcr.io/myaccount make akri-controller`: builds the Akri controller container for all platforms and stores them in a container registry, `ghcr.io/myaccount`.
+* `make akri`: build akri core container images for all architectures (build only, no push nor load)
+* `make akri PLATFORMS=arm64`: build akri core containers for ARM64 (build only, no push nor load)
+* `make akri PREFIX=ghcr.io/myaccount PUSH=1`: builds all of the Akri core containers and stores them in a container registry, `ghcr.io/myaccount`.
+* `make akri PREFIX=ghcr.io/myaccount LABEL_PREFIX=local PUSH=1`: builds all of the Akri containers and stores them in a container registry, `ghcr.io/myaccount` with labels set to `local`.
+* `make akri PREFIX=ghcr.io/myaccount PLATFORMS=amd64`: builds all of the Akri containers for AMD64 and stores them in a container registry, `ghcr.io/myaccount`.
+* `make akri-controller PREFIX=ghcr.io/myaccount PUSH=1`: builds the Akri controller container for all platforms and stores them in a container registry, `ghcr.io/myaccount`.
+* `make akri LOAD=1`: build akri core containers for the local architecture and load them into the docker daemon
 
 ### make targets
 
-For each component, there will be a common set of targets:
+Here is the list of supported make targets:
 
-* `akri-<component>`: this target will cross-build Akri and build+push this component's container for all platforms
-* `akri-docker-<component>`: this target will build+push this component's container for all platforms
-* `<component>-build`: this target will build this component's container for all platforms
-* `<component>-build-amd64`: this target will build this component's container for amd64
-* `<component>-build-arm32`: this target will build this component's container for arm32
-* `<component>-build-arm64`: this target will build this component's container for arm64
-* `<component>-docker-per-arch`: this target will push this component's container for all platforms
-* `<component>-docker-per-arch-amd64`: this target will push this component's container for amd64
-* `<component>-docker-per-arch-arm32`: this target will push this component's container for arm32
-* `<component>-docker-per-arch-arm64`: this target will push this component's container for arm64
-* `<component>-docker-multi-arch-create`: this target will create a multi-arch manifest for this component and include all platforms
-* `<component>-docker-multi-arch-push`: this target will push a multi-arch manifest for this component
+* `all`: builds all core samples and intermediate container images
+* `push`: shortcut for `all PUSH=1`
+* `load`: shortcut for `all LOAD=1`
+* `akri`: builds all core container images
+* `samples`: builds all samples container images
+* `akri-<component>`: builds the container image for this specific core component, core components are currently one of these: agent, agent-full, controller, webhook-configuration, debug-echo-discovery-handler, onvif-discovery-handler, opcua-discovery-handler, udev-discovery-handler
+* `<sample-name>`: builds this specific sample container image, can be one of: opcua-monitoring-broker, onvif-video-broker, akri-udev-video-broker, anomaly-detection-app, video-streaming-app
+* `opencv-base`: see [opencvsharp-build](#opencvsharp-build)
 
 ### Adding a new component
 
-To add a new Rust-based component, follow these steps (substituting the new component name for `<new-component>`): 
+To add a new Rust-based component, follow these steps:
 
-1. Add `$(eval $(call add_rust_targets,<new-component>,<new-component>))` to `build/akri-containers.mk` 
-1. Create `build/Dockerfile.<new-component>`
-> A simple way to do this is to copy `build/Dockerfile.agent` and replace `agent` with whatever `<new-component>` is. 
-
-1. Create `.github/workflows/build-<new-component>-container.yml` A simple way to do this is to copy `.github/workflows/build-agent-container.yml` and replace `agent` with whatever `<new-component>` is.
+1. Add the new component to `build/akri-containers.mk` as a dependency to the `akri` target
+1. Add the new component to the list of components to build in the `build-others` job of `.github/workflows/build-rust-containers.yml`
 
 ## Intermediate components
 
 These are the intermediate components:
 
-* [rust-crossbuild](https://github.com/orgs/project-akri/packages/container/package/akri%2Frust-crossbuild)
 * [opencvsharp-build](https://github.com/orgs/project-akri/packages/container/package/akri%2Fopencvsharp-build)
-
-### rust-crossbuild
-
-This container is used by the Akri cross-build process. The main purpose of these containers is to provide `Cargo cross` with a Rust build environment that has all the required dependencies installed. This container can be built locally for all platforms using this command:
-
-```bash
-BUILD_AMD64=1 BUILD_ARM32=1 BUILD_AMD64=1 make rust-crossbuild
-```
-
-If a change needs to be made to this container, 2 pull requests are needed. 
-
-1. Create PR with desired `rust-crossbuild` changes (new dependencies, etc) AND update `BUILD_RUST_CROSSBUILD_VERSION` in `build/intermediate-containers.mk`. This PR is intended to create the new version of `rust-crossbuild` (not to use it). 
-1. After 1st PR is merged and the new version of `rust-crossbuild` is pushed to ghcr.io/akri, create PR with any changes that will leverage the new version of `rust-crossbuild` AND update `Cross.toml` (the `BUILD_RUST_CROSSBUILD_VERSION` value specified in step 1 should be each label's suffix). This PR is intended to **use** the new version of `rust-crossbuild`.
 
 ### opencvsharp-build
 
 This container is used by the [onvif-video-broker](https://github.com/orgs/project-akri/packages/container/package/akri%2Fonvif-video-broker) as part of its build process. The main purpose of this container is to prevent each build from needing to build the OpenCV C\# platform. This container can be built locally for all platforms using this command:
 
 ```bash
-BUILD_AMD64=1 BUILD_ARM32=1 BUILD_AMD64=1 make opencv-base
+make opencv-base
 ```
 
-If a change needs to be made to this container, 2 pull requests are needed. 
+If a change needs to be made to this container, 2 pull requests are needed.
 
-1. Create PR with desired `opencvsharp-build` changes (new dependencies, etc) AND update `BUILD_OPENCV_BASE_VERSION` in `build/intermediate-containers.mk`. This PR is intended to create the new version of `opencvsharp-build` (not to use it). 
-1. After 1st PR is merged and the new version of `opencvsharp-build` is pushed to ghcr.io/akri, create PR with any changes that will leverage the new version of `opencvsharp-build` AND update `USE_OPENCV_BASE_VERSION` in `build/akri-containers.mk`. This PR is intended to **use** the new version of `opencvsharp-build`.
+1. Create PR with desired `opencvsharp-build` changes (new dependencies, etc) AND update `BUILD_OPENCV_BASE_VERSION` in `build/intermediate-containers.mk`. This PR is intended to create the new version of `opencvsharp-build` (not to use it).
+1. After 1st PR is merged and the new version of `opencvsharp-build` is pushed to ghcr.io/akri, create PR with any changes that will leverage the new version of `opencvsharp-build` AND update `USE_OPENCV_BASE_VERSION` in `build/samples.mk`. This PR is intended to **use** the new version of `opencvsharp-build`.
 
 ## Automated builds usage
 
-The automated CI builds essentially run these commands, where `<component>` is one of (`controller`\|`agent`\|`udev`\|`webhook-configuration`\|`onvif`\|`opcua-monitoring`\|`anomaly-detection`\|`streaming`) and `<platform>` is one of (`amd64`\|`arm32`\|`arm64`):
+The automated CI builds are using several jobs and leverages the docker build-push action, but it is equivalent to:
 
 ```bash
-# Install the Rust cross building tools
-make install-cross
-# Cross-builds Rust code for specified platform
-make akri-cross-build-<platform>
-# Cross-builds Rust code for specified component and platform
-make <component>-build-<platform>
-# Create container for specified component and platform using versioned label
-LABEL_PREFIX="v$(cat version.txt)-dev" make <component>-build-<platform>
-# Create container for specified component and platform using latest label
-LABEL_PREFIX=`latest-dev` make <component>-build-<platform>
-
-PREFIX=`ghcr.io/project-akri`
-# Push container for specified component and platform with versioned label to container registry
-LABEL_PREFIX="v$(cat version.txt)-dev" make <component>-docker-per-arch-<platform>
-# Push container for specified component and platform with latest label to container registry
-LABEL_PREFIX=`latest-dev` make <component>-docker-per-arch-<platform>
-
-DOCKER_CLI_EXPERIMENTAL=`enabled`
-PREFIX=`ghcr.io/project-akri`
-# Create manifest for multi-arch versioned container
-LABEL_PREFIX="v$(cat version.txt)-dev" make <component>-docker-multi-arch-create
-# Push manifest for multi-arch versioned container
-LABEL_PREFIX="v$(cat version.txt)-dev" make <component>-docker-multi-arch-push
-# Create manifest for multi-arch latest container
-LABEL_PREFIX=`latest-dev` make <component>-docker-multi-arch-create
-# Push manifest for multi-arch latest container
-LABEL_PREFIX=`latest-dev` make <component>-docker-multi-arch-push
+# Build and push all images on ghcr.io/project-akri using v<version>-dev label
+make push PREFIX="ghcr.io/project-akri" LABEL_PREFIX="v$(cat version.txt)-dev" 
 ```
 
 ## Build and run Akri without a Container Registry
 
 For development and/or testing, it can be convenient to run Akri without a Container Registry. For example, the Akri CI tests that validate pull requests build Akri components locally, store the containers only in local docker, and configure Helm to only use the local docker containers.
 
-There are two steps to this. For the sake of this demonstration, only the amd64 version of the agent and controller will be built, but this method can be extended to any and all components: 
+There are two steps to this. For the sake of this demonstration, only the local architecture version of the agent and controller will be built, but this method can be extended to any and all components:
 
 1. Build:
 
 ```bash
-    # Only build AMD64
-    BUILD_AMD64=1
     # PREFIX can be anything, as long as it matches what is specified in the Helm command
     PREFIX=no-container-registry
     # LABEL_PREFIX can be anything, as long as it matches what is specified in the Helm command
     LABEL_PREFIX=dev
-    # Build the Rust code
-    make akri-build
-    # Build the controller container locally for amd64
-    make controller-build-amd64
-    # Build the agent container locally for amd64
-    make agent-build-amd64
+    # Build and load the controller and the agent
+    make akri-controller akri-agent LOAD=1
 ```
 
 1. Runtime
@@ -169,14 +119,13 @@ There are two steps to this. For the sake of this demonstration, only the amd64 
    ```bash
     # Specify pullPolicy as Never
     # Specify repository as $PREFIX/<component>
-    # Specify tag as $LABEL_PREFIX-amd64
+    # Specify tag as $LABEL_PREFIX
     helm install akri ./deployment/helm \
         $AKRI_HELM_CRICTL_CONFIGURATION \
         --set agent.image.pullPolicy=Never \
         --set agent.image.repository="$PREFIX/agent" \
-        --set agent.image.tag="$LABEL_PREFIX-amd64" \
+        --set agent.image.tag="$LABEL_PREFIX" \
         --set controller.image.pullPolicy=Never \
         --set controller.image.repository="$PREFIX/controller" \
-        --set controller.image.tag="$LABEL_PREFIX-amd64"
+        --set controller.image.tag="$LABEL_PREFIX"
    ```
-

--- a/docs/development/test-cases-workflow.md
+++ b/docs/development/test-cases-workflow.md
@@ -121,7 +121,7 @@ There are other options in addition to `--distribution` that affect the test run
 | `--release` | Use `akri` chart instead of `akri-dev` |
 | `--test-version` | Version of the chart to use |
 | `--use-local` | Use local chart (i.e `/deployment/helm` and local images) |
-| `--local-tag` | When using local images, the tag used by images (by default will look for `pr-amd64` tag) |
+| `--local-tag` | When using local images, the tag used by images (by default will look for `pr` tag) |
 
 ## Technical details and writing new tests
 


### PR DESCRIPTION
This adapts the development sections of the documentation after the revamp of the build system in akri repository