### PR TITLE
Adding adopter section and link to adopters.md.

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -79,6 +79,9 @@ When you submit a pull request, the DCO-bot will automatically assess whether yo
 
 For more details and the exact DCO text, you can visit [Developer Certificate of Origin](developercertificate.org).
 
+## Adopters
+If you are leveraging Akri for your solution, we highly encourage you to add your organization or project information to our [adopter list](https://github.com/project-akri/akri/blob/main/ADOPTERS.md). Please submit a pull request against the [ADOPTERS.md in the Akri GitHub](https://github.com/project-akri/akri/blob/main/ADOPTERS.md). Your feedback is highly appreciated and would help us to justify the future investment in this project.
+
 ## Code of Conduct
 
 Participation in the Akri community is governed by the [Code of Conduct](../../CODE_OF_CONDUCT.md).

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -80,7 +80,7 @@ When you submit a pull request, the DCO-bot will automatically assess whether yo
 For more details and the exact DCO text, you can visit [Developer Certificate of Origin](developercertificate.org).
 
 ## Adopters
-If you are leveraging Akri for your solution, we highly encourage you to add your organization or project information to our [adopter list](https://github.com/project-akri/akri/blob/main/ADOPTERS.md). Please submit a pull request against the [ADOPTERS.md in the Akri GitHub](https://github.com/project-akri/akri/blob/main/ADOPTERS.md). Your feedback is highly appreciated and would help us to justify the future investment in this project.
+If you are leveraging Akri for your solution, we highly encourage you to add your organization or project information to our [adopter list](https://github.com/project-akri/akri/blob/main/ADOPTERS.md). Please submit a pull request against the [ADOPTERS.md in the Akri GitHub](https://github.com/project-akri/akri/blob/main/ADOPTERS.md). Your participation helps us prioritize feature development in the project.
 
 ## Code of Conduct
 

--- a/docs/community/roadmap.md
+++ b/docs/community/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Akri uses a [single project board](https://github.com/project-akri/akri/projects/1) to track issues. The board illustrates what features are requested by community members, currently being investigated, and under development. We review the project board each [community meeting](https://hackmd.io/@akri/S1GKJidJd) to make sure all issues are addressed and categorized. Additionally, Akri is currently working towards a full-feature stable `v1.0` release. Reference the [Akri 1.0 project board](https://github.com/orgs/project-akri/projects/2) to see what exciting features and milestones are coming to Akri `v1.0`.
+Akri uses a [single project board](https://github.com/orgs/project-akri/projects/1) to track issues. The board illustrates what features are requested by community members, currently being investigated, and under development. We review the project board each [community meeting](https://hackmd.io/@akri/S1GKJidJd) to make sure all issues are addressed and categorized. Additionally, Akri is currently working towards a full-feature stable `v1.0` release. Reference the [Akri 1.0 project board](https://github.com/orgs/project-akri/projects/2) to see what exciting features and milestones are coming to Akri `v1.0`.
 
 The following detail a couple of the larger goals of Akri: to discover more devices and provide more deployment strategies.
 


### PR DESCRIPTION
Adding the adopter section and instruction for adopters to add themselves.
Also fixing a broken link:

> **Roadmap**
> Akri uses a [single project board](https://github.com/project-akri/akri/projects/1) to track issues.