### PR TITLE
docs: update rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Akri's documentation is divided into six sections:
 
 1. :blue_book: User Guide: Documentation for Akri users.
 1. :mag_right: Discovery Handlers: Documentation on how to configure Akri using Akri's currently supported Discovery Handlers
-1. :rocket: Demos: End-to-End demos that demostrate how Akri can discover and use devices. Contain sample brokers and end applications.
+1. :rocket: Demos: End-to-End demos that demonstrate how Akri can discover and use devices. Contain sample brokers and end applications.
 1. :gear: Architecture: Documentation that details the design and implementation of Akri's components.
 1. :computer: Development: Documentation for Akri developers or how to build, test, and extend Akri.
 1. :tada: Community: Information on what's next for Akri and how to get involved!

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ Akri's documentation is divided into six sections:
 
 1. 📘 [User Guide](./user-guide/getting-started.md): Documentation for Akri users.
 1. 🔎 [Discovery Handlers](./discovery-handlers/onvif.md): Documentation on how to configure Akri using Akri's currently supported Discovery Handlers
-1. 🚀 [Demos](./demos/usb-camera-demo.md): End-to-End demos that demostrate how Akri can discover and use devices. Contain sample brokers and end applications.
+1. 🚀 [Demos](./demos/usb-camera-demo.md): End-to-End demos that demonstrate how Akri can discover and use devices. Contain sample brokers and end applications.
 1. ⚙️ [Architecture](./architecture/architecture-overview.md): Documentation that details the design and implementation of Akri's components.
 1. 💻 [Development](./development/development.md): Documentation for Akri developers or how to build, test, and extend Akri.
 1. 🎉 [Community](./community/roadmap.md): Information on what's next for Akri and how to get involved!

--- a/docs/architecture/agent-in-depth.md
+++ b/docs/architecture/agent-in-depth.md
@@ -28,7 +28,7 @@ To enable resource sharing, the Akri Agent creates and updates the `Instance.dev
 
 For more detailed information, see the [in-depth resource sharing doc](resource-sharing-in-depth.md).
 
-Akri Agent also exposes all discovered resources at Configuration level. Configuration level resources can be referred by the name of Configuration so Configuration name can be used to requst resources without the need to know the specific Instances id to request. Agent will behind the scenes do the work of selecting which Instances to reserve.
+Akri Agent also exposes all discovered resources at Configuration level. Configuration level resources can be referred by the name of Configuration so Configuration name can be used to request resources without the need to know the specific Instances id to request. Agent will behind the scenes do the work of selecting which Instances to reserve.
 
 For more detailed information about Configuration level resource, see the [Configuration-level resources doc](configuration-level-resource-in-depth.md).
 
@@ -50,7 +50,7 @@ It is common for a device to require authentication in order to access its prope
 `discoverProperties`, if it is specified in Configuration, Agent reads the content and generate a list of string key-value pair properties and pass the list to
 Discovery Handler along with `discoveryDetails`.
 
-Agent supports plain text, K8s `secret` and `configMap` in the schema of `discoverProperies`. An example below shows how each type of property is specified in `discoveryProperties`. The `name` of property is required and needs to be in C_IDENTIFIER format. The value can be specified by `value` or `valueFrom`. For value specified by `valueFrom`, it can be from `secret` or `configMap`. The `optional` attribute is default to `false`, it means if the data doesn't exist (in the `secret` or `configMap`), the Configuration deployment
+Agent supports plain text, K8s `secret` and `configMap` in the schema of `discoverProperties`. An example below shows how each type of property is specified in `discoveryProperties`. The `name` of property is required and needs to be in C_IDENTIFIER format. The value can be specified by `value` or `valueFrom`. For value specified by `valueFrom`, it can be from `secret` or `configMap`. The `optional` attribute is default to `false`, it means if the data doesn't exist (in the `secret` or `configMap`), the Configuration deployment
 will fail. If `optional` is `true`, Agent will ignore the entry if the data doesn't exist, and pass all exist properties to Discovery Handler, the Configuration deployment will success.
 
 ```yaml

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -44,7 +44,7 @@ Alternatively, you could skip running `version.sh` file altogether. Once you mak
 - `/version minor` for non-breaking feature changes
 - `/version major` for major and/or breaking changes
 
-Commenting these commmands on your pull request will automatically update the version for you and push the changes to your pull request branch.
+Commenting these commands on your pull request will automatically update the version for you and push the changes to your pull request branch.
 
 ## Logging
 

--- a/docs/demos/onvif-authentication-access.md
+++ b/docs/demos/onvif-authentication-access.md
@@ -105,9 +105,9 @@ helm upgrade akri akri-helm-charts/akri-dev \
    --set onvif.configuration.capacity=3 \
    --set onvif.configuration.discoveryProperties[0].name=device_credential_list \
    --set onvif.configuration.discoveryProperties[0].valueFrom.secretKeyRef.name=onvif-auth-secret \
-   --set onvif.configuration.discoveryProperties[0].valueFrom.secretKeyRef.namesapce=default \
+   --set onvif.configuration.discoveryProperties[0].valueFrom.secretKeyRef.namespace=default \
    --set onvif.configuration.discoveryProperties[0].valueFrom.secretKeyRef.key=device_credential_list \
-   --set onvif.configuration.discoveryProperties[0].valueFrom.secretKeyRef.optoinal=false \
+   --set onvif.configuration.discoveryProperties[0].valueFrom.secretKeyRef.optional=false \
    --set onvif.configuration.brokerPod.image.repository="ghcr.io/project-akri/akri/onvif-video-broker" \
    --set onvif.configuration.brokerPod.image.tag="latest-dev" \
    --set onvif.configuration.brokerPod.image.pullPolicy="Always" \

--- a/docs/demos/usb-camera-demo-rpi4.md
+++ b/docs/demos/usb-camera-demo-rpi4.md
@@ -39,7 +39,7 @@ The following will be covered in this demo:
    sudo kubeadm init
    ```
 
-   You will then need to setup kubenetes config and environment variables using the commands below
+   You will then need to setup kubernetes config and environment variables using the commands below
 
    ```sh
    mkdir -p $HOME/.kube

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -31,11 +31,11 @@ The majority of Akri is written in Rust. To install Rust and Akri's component's 
 ./build/setup.sh
 ```
 
-If you previously installed Rust ensure you are using the v1.82.0 toolchain that Akri's build system uses:
+If you previously installed Rust ensure you are using the v1.88.0 toolchain that Akri's build system uses:
 
 ```sh
-sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.82.0
-rustup default 1.82.0
+sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.88.0
+rustup default 1.88.0
 cargo version
 ```
 
@@ -49,17 +49,17 @@ cargo version
    ./build/setup.sh
    ```
 
-   If you previously installed Rust, ensure you are using the v1.82.0 toolchain that Akri's build system uses:
+   If you previously installed Rust, ensure you are using the v1.88.0 toolchain that Akri's build system uses:
 
    ```sh
-   sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.82.0
+   sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.88.0
    ```
 
-   Then, configure your current shell to see Cargo and set `v1.82.0` as default toolchain.
+   Then, configure your current shell to see Cargo and set `v1.88.0` as default toolchain.
 
    ```sh
    source $HOME/.cargo/env
-   rustup default 1.82.0
+   rustup default 1.88.0
    cargo version
    ```
 

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -113,7 +113,7 @@ To locally run Akri's Agent, Controller, and Discovery Handlers as part of a Kub
         sudo -E DEBUG_ECHO_INSTANCES_SHARED=true ENABLE_DEBUG_ECHO=1 RUST_LOG=info METRICS_PORT=8082 KUBECONFIG=$HOME/.kube/config DISCOVERY_HANDLERS_DIRECTORY=~/tmp/akri AGENT_NODE_NAME=myNode $HOME/.cargo/bin/cargo run
         ```
 
-        > Note: `DISCOVERY_HANDLERS_DIRECTORY` is where Akri agent creates an unix domain socket for discovery handler's registeration. This example uses ~/tmp/akri that should exist or is created before executing this command.
+        > Note: `DISCOVERY_HANDLERS_DIRECTORY` is where Akri agent creates an unix domain socket for discovery handler's registration. This example uses ~/tmp/akri that should exist or is created before executing this command.
 
         By default, the Agent does not have embedded Discovery Handlers. To allow embedded Discovery Handlers in the
         Agent, turn on the `agent-full` feature and the feature for each Discovery Handler you wish to embed -- Debug echo

--- a/docs/development/test-cases-workflow.md
+++ b/docs/development/test-cases-workflow.md
@@ -107,7 +107,7 @@ To run all the tests run `poetry run pytest -v --distribution ${DISTRO}`, with `
 
 To run specific test suite, add the suite file as argument to the pytest command (e.g add `test_webhook.py`).
 
-To run a specific test in a test suite add the fully quialified test name as argument to the pytest command (e.g add `test_webhook::test_valid_configuration_accepted`).
+To run a specific test in a test suite add the fully qualified test name as argument to the pytest command (e.g add `test_webhook::test_valid_configuration_accepted`).
 
 You can specify multiple tests or test suites in you pytest command.
 
@@ -126,15 +126,15 @@ There are other options in addition to `--distribution` that affect the test run
 ## Technical details and writing new tests
 
 All end to end tests suites are located in `/test/e2e/`, as we use pytest to run those, a test suite file must be named `test_${SUITE}.py`.
-Within these files every `test_*` functions will run independently, fixtures are here to help in setting up and tearing down the test evironment.
+Within these files every `test_*` functions will run independently, fixtures are here to help in setting up and tearing down the test environment.
 
 Every fixture will get set up when first used in scope (everything before the `yield` is executed), and teared down after last use in scope (everything after the `yield` is executed).
 Useful scopes for our usecases are `session` for the entire time of the pytest run, `module` for a specific suite and `function` for a specific test.
-An `autouse` fixture will get automatically added without explicitely asking for it.
+An `autouse` fixture will get automatically added without explicitly asking for it.
 
 Akri will be installed thanks to the `autouse` fixture `install_akri`, the scope of this fixture is `module`, meaning it will get installed and uninstalled
 for every test suite. This fixture is configured by the module variable `discovery_handlers` that must be set to a list of discovery handlers to enable.
 
 A test passes if the function return; a test fails if the function raises an exception.
 
-Be careful when writing new tests, the test order is **not** guarenteed, so make sure your test reverts any modification.
+Be careful when writing new tests, the test order is **not** guaranteed, so make sure your test reverts any modification.

--- a/docs/discovery-handlers/onvif.md
+++ b/docs/discovery-handlers/onvif.md
@@ -178,7 +178,7 @@ stringData:
 Device credential ref list is similar to Device credential list except the device ids are listed and the credentials are references
 to another entries in the Akri `discoveryProperties`. The key name for device credential ref list is “`device_credential_ref_list`”.
 
-For example, the device credential ref list below contains an array of “device id”->”credential reference” objects. The credential of device id “5f5a69c2-e0ae-504f-829b-00fcdab169cc” is refered to (username-> device1_username, password->device1_password). The device1_username and device1_password are entries in Akri discoverProperties that point to the actual secret information in Kubernetes Secrets. Note different device ids may use the same secret reference.
+For example, the device credential ref list below contains an array of “device id”->”credential reference” objects. The credential of device id “5f5a69c2-e0ae-504f-829b-00fcdab169cc” is referred to (username-> device1_username, password->device1_password). The device1_username and device1_password are entries in Akri discoverProperties that point to the actual secret information in Kubernetes Secrets. Note different device ids may use the same secret reference.
 
 ```yaml
 - name: "device_credential_ref_list"
@@ -365,7 +365,7 @@ helm install akri akri-helm-charts/akri \
 
 The Onvif sample broker (`akri-onvif-video-broker`) can be configured to access Secret and ConfigMap data, if configured, it expects the Secret and ConfigMap data are
 mounted as files. The sample broker checks the environment variables `CREDENTIAL_DIRECTORY` for the directory that contains Secret data and
-`CREDENTIAL_CONFIGMAP_DIRECTORY` for direcctory contains configMap data. `CREDENTIAL_CONFIGMAP_DIRECTORY` is optional. When the sample broker launched, the uuids of
+`CREDENTIAL_CONFIGMAP_DIRECTORY` for directory contains configMap data. `CREDENTIAL_CONFIGMAP_DIRECTORY` is optional. When the sample broker launched, the uuids of
 discovered Onvif devices are set in the environment variables `ONVIF_DEVICE_UUID_{INSTANCE_HASH_ID}`, the sample broker picks the first one found from the environment variables `ONVIF_DEVICE_UUID_{INSTANCE_HASH_ID}` as device uuid and get match credential from files under `CREDENTIAL_DIRECTORY` and `CREDENTIAL_CONFIGMAP_DIRECTORY`.
 The schema of how the Secret/ConfigMap files are organized aligned to the schema that Onvif Discovery Handler used for passing the secret data, as follow:
 
@@ -375,7 +375,7 @@ The schema of how the Secret/ConfigMap files are organized aligned to the schema
    not be found.
 2. If the sample broker can not find a matched credential from the username/password secret files directly, it looks for credentials from the device credential ref list `device_credential_ref_list`. The sample broker try to get a file name `device_credential_ref_list` from `CREDENTIAL_CONFIGMAP_DIRECTORY`, and if the file does not
    exists, it tries to get the same file name under `CREDENTIAL_DIRECTORY`. The credential ref list should contains reference entries to the actual credentals. The sample
-   broker look up the device uuid from the list to get the credential referece and read the actual credential files from `CREDENTIAL_DIRECTORY`. Similar to the fallback credenial "username_default" and "password_default", a credential ref entry with key "default" indicates the fallback credental.
+   broker look up the device uuid from the list to get the credential reference and read the actual credential files from `CREDENTIAL_DIRECTORY`. Similar to the fallback credenial "username_default" and "password_default", a credential ref entry with key "default" indicates the fallback credental.
 3. if the sample broker can not find a matched credental from credential ref list, it looks for credentials from crdential list `device_credential_list`. The sample broker try to get a file name `device_credential_list` from `CREDENTIAL_CONFIGMAP_DIRECTORY`, and if the file does not exist, it tries to get the same file name under `CREDENTIAL_DIRECTORY`. The credential list should contains actual credential entries. The sample broker look up the device uuid from the list to get the credential. Similarly, a credential entry with key "default" indicates the fallback credental.
 
 The following example shows how the credential information is organized in Secret and ConfigMap. There are 4 credentials specified in this example, credential for device id

--- a/docs/user-guide/requesting-akri-resources.md
+++ b/docs/user-guide/requesting-akri-resources.md
@@ -64,7 +64,7 @@ kubectl get akrii onvif-camera-<id> -o yaml
 
 ## Requesting resources at Configuration level
 
-Akri also exposes all discovered devices as resources at Configuration level. Configuration level resources can be referred by the name of Configuration. With Configuration-level resources, instead of needing to know the specific Instances id `onvif-camera-<id>` to request, you can use Configuration name `<configuration-name>` to requst resources. Agent will behind the scenes do the work of selecting which Instances to reserve.
+Akri also exposes all discovered devices as resources at Configuration level. Configuration level resources can be referred by the name of Configuration. With Configuration-level resources, instead of needing to know the specific Instances id `onvif-camera-<id>` to request, you can use Configuration name `<configuration-name>` to request resources. Agent will behind the scenes do the work of selecting which Instances to reserve.
 
 ```yaml
 apiVersion: apps/v1

--- a/proposals/credentials-passing.md
+++ b/proposals/credentials-passing.md
@@ -14,7 +14,7 @@ Whether secrets should be passed as environment variables or mounted files could
 
 ### How Secrets are used in OPC UA
 
-For OPC UA, a client maintains a certificate store at a certain path. So the Kubernetes Secrets only need to be passed in at the path expected by the OPC UA Client (Akri Broker). In this case, as shown in the abreviated broker PodSpec below, that path is /etc/opcua-cert/client-pki. Specifically, the client certificate can be found at /etc/opcua-cert/client-pki/own/certs/AkriClient.der.
+For OPC UA, a client maintains a certificate store at a certain path. So the Kubernetes Secrets only need to be passed in at the path expected by the OPC UA Client (Akri Broker). In this case, as shown in the abbreviated broker PodSpec below, that path is /etc/opcua-cert/client-pki. Specifically, the client certificate can be found at /etc/opcua-cert/client-pki/own/certs/AkriClient.der.
 
 ```
 brokerPodSpec:

--- a/proposals/job-brokers.md
+++ b/proposals/job-brokers.md
@@ -14,7 +14,7 @@ This document discusses how to add support for deploying terminating Pods to use
 | `capacity` | Maximum amount of containers that can use a device. Defines the number of usage slots a device's device plugin advertises to the kubelet                                                                                                               |
 | broker     | The word Akri uses to describe the workload (currently only Pods) that the Akri Controller automatically deploys to use discovered IoT devices                                                                                                         |
 | Pod        | The smallest deployable unit in Kubernetes                                                                                                                                                                                                             |
-| Jobs       | a [Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) is a higher level Kubernetesobject that creates one or more (by increasing `parallism` value) identical Pods and will retry until a set number of them successfully terminate. |
+| Jobs       | a [Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) is a higher level Kubernetesobject that creates one or more (by increasing `parallelism` value) identical Pods and will retry until a set number of them successfully terminate. |
 
 ## Background
 

--- a/proposals/simple-protocol-extension.md
+++ b/proposals/simple-protocol-extension.md
@@ -14,7 +14,7 @@ Wouldn't it be great if users could deploy only the implementations they wanted?
 
 1. Within the existing code, create set of build flags that allow people to easily include/exclude protocols. This would provide a simple method for people to get exactly what they want ... the build system would likely still create the "all-in-one" Agent executable/containers.
 1. Create a plugin system that allows Agent to load any libraries that are available. This would allow people to modify our Dockerfiles to embed only the protocols they desire.
-1. Implement all protocols as Pods that can be deployed where needed. In essence, each protocol discovery implementation would be moved out of Agent and into its own executable. This executable would notify Agent of its discovery results (maybe over gRPC, similar to Kuberetes' device plugin framework). This would provide an ability to implement protocol discovery in any programming language and without any dependencies on the Akri binaries. To enable a specific protocol in a cluster, the operator would need to deploy both Agent and the specific protocol container. Our build system would produce Agent (without any protocols) ... and would build a container for each protocol implementation.
+1. Implement all protocols as Pods that can be deployed where needed. In essence, each protocol discovery implementation would be moved out of Agent and into its own executable. This executable would notify Agent of its discovery results (maybe over gRPC, similar to Kubernetes' device plugin framework). This would provide an ability to implement protocol discovery in any programming language and without any dependencies on the Akri binaries. To enable a specific protocol in a cluster, the operator would need to deploy both Agent and the specific protocol container. Our build system would produce Agent (without any protocols) ... and would build a container for each protocol implementation.
 1. Akri Agent (minus specific protocol implementations) could be exposed as a library.  Each protocol would create its own tailored Agent that was basically an implementation of the DiscoveryHandler trait and an invocation of the Agent library. This would simplify anyone's effort to implement a new protocol and deploy it in isolation.
    ```rust
    struct FooProtocol {}
@@ -28,7 +28,7 @@ Wouldn't it be great if users could deploy only the implementations they wanted?
        akri_agent.start();
    }
    ```
-   This idea could be extended to allow mutliple protocol handlers. That would allow our build system to create an "all-in-one" Agent example:
+   This idea could be extended to allow multiple protocol handlers. That would allow our build system to create an "all-in-one" Agent example:
    ```rust
    pub fn main() {
        // add all protocol handlers

--- a/proposals/zeroconf.md
+++ b/proposals/zeroconf.md
@@ -44,7 +44,7 @@ The Akri discovery handler is written in Rust and uses [`zeroconf`](https://crat
 
 The Akri Agent is deployed to a Kubernetes cluster. Kubernetes clusters commonly run in-cluster DNS services (nowadays [`CoreDNS`](https://kubernetes.io/docs/tasks/administer-cluster/coredns/)). For this reason, the applicability of the Akri Zeroconf protocol is to devices not accessible within the cluster. The benefit of the Akri Zeroconf protocol is to make off-cluster Zeroconf-accessible hosts (devices) and services accessible to Kubernetes cluster resources (e.g. applications).
 
-For Zeroconf discovery to occur, the Agent's Pod must leverage several Zeroconf depdendencies and libraries. These depdendencies not only expand the size of the Akri Agent (~800MB) but they increase the Agent's surface area and increase the possibility of vulnerabilities.
+For Zeroconf discovery to occur, the Agent's Pod must leverage several Zeroconf dependencies and libraries. These dependencies not only expand the size of the Akri Agent (~800MB) but they increase the Agent's surface area and increase the possibility of vulnerabilities.
 
 Discovery is a key functionality of Zeroconf and is straightforward to implement. See the [Browsing services](https://crates.io/crates/zeroconf#browsing-services) examples of the `zeroconf` crate.
 


### PR DESCRIPTION
The PR:
 
- Updates Rust to v1.88.0 ([ref](https://github.com/project-akri/akri/blob/main/Cargo.toml#L31)).
- Fix a few typos in the repository.